### PR TITLE
[android] キーボードを避けるように

### DIFF
--- a/app-android/app/src/main/kotlin/com/example/home_hackathon2/ui/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/example/home_hackathon2/ui/MainActivity.kt
@@ -3,10 +3,12 @@ package com.example.home_hackathon2.ui
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         setContent {
             App()

--- a/app-android/app/src/main/kotlin/com/example/home_hackathon2/ui/initial/InitialScreen.kt
+++ b/app-android/app/src/main/kotlin/com/example/home_hackathon2/ui/initial/InitialScreen.kt
@@ -18,13 +18,15 @@ import com.example.home_hackathon2.ui.res.COLOR_DARK
 import com.example.home_hackathon2.ui.res.COLOR_LIGHT
 import com.example.home_hackathon2.ui.widget.BorderTextField
 import com.example.home_hackathon2.ui.widget.TintButton
+import com.example.home_hackathon2.ui.widget.paddingBottomIme
 
 @Composable
 fun InitialScreen() {
     Column(
         modifier = Modifier
+            .fillMaxHeight()
             .padding(horizontal = 30.dp)
-            .fillMaxHeight(),
+            .paddingBottomIme(),
         verticalArrangement = Arrangement.Center
     ) {
         Message(

--- a/app-android/app/src/main/kotlin/com/example/home_hackathon2/ui/widget/WindowInsets.kt
+++ b/app-android/app/src/main/kotlin/com/example/home_hackathon2/ui/widget/WindowInsets.kt
@@ -1,0 +1,41 @@
+package com.example.home_hackathon2.ui.widget
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.dp
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsAnimationCompat
+import androidx.core.view.WindowInsetsCompat
+
+fun Modifier.paddingBottomIme(): Modifier = composed {
+    val view = LocalView.current
+    val density = LocalDensity.current
+    val height = remember {
+        mutableStateOf(0.dp)
+    }
+    DisposableEffect(view) {
+        val callback = object : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_STOP) {
+            override fun onProgress(
+                insets: WindowInsetsCompat,
+                runningAnimations: MutableList<WindowInsetsAnimationCompat>
+            ): WindowInsetsCompat {
+                val bottom = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+                height.value = density.run {
+                    bottom.toDp()
+                }
+                return insets
+            }
+        }
+        ViewCompat.setWindowInsetsAnimationCallback(view, callback)
+        onDispose {
+            ViewCompat.setWindowInsetsAnimationCallback(view, null)
+        }
+    }
+    padding(bottom = height.value)
+}


### PR DESCRIPTION
* キーボードの高さ分padding bottomを追加し、キーボードを避けるようにする

## before
https://user-images.githubusercontent.com/13435109/116903002-d1265200-ac76-11eb-90ce-337806d58a0b.mp4

## after
https://user-images.githubusercontent.com/13435109/116903020-d4214280-ac76-11eb-8d95-ff7dacaa9bf6.mp4


